### PR TITLE
Add GCP Cloud Run monitoring with Terraform - log-based alerts and latency dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,142 @@
-# gcp-cloud-run-monitoring
-Repository for infra.new project: gcp-cloud-run-monitoring
+
+# GCP Cloud Run Monitoring with Terraform
+
+This project sets up comprehensive monitoring for Google Cloud Run services including log-based alerts and latency monitoring dashboards.
+
+## Features
+
+### 🚨 Alert Policies
+- **High Error Rate**: Triggers when error rate exceeds threshold (default: 5 errors/minute)
+- **High Latency**: Triggers when 95th percentile latency exceeds threshold (default: 2000ms)
+- **Critical Errors**: Log-based alert for CRITICAL/EMERGENCY/FATAL log entries
+
+### 📊 Monitoring Dashboard
+- Request count over time
+- Request latency (95th percentile)
+- Error rate tracking
+- Instance count monitoring
+
+### 📧 Notifications
+- Email notifications for all alerts
+- Rate limiting to prevent spam (max 1 notification per 5 minutes for log-based alerts)
+
+## Quick Start
+
+1. **Update Configuration**
+   ```bash
+   # Edit infra/environments/dev/main.tf
+   # Set your GCP project ID and alert email
+   ```
+
+2. **Deploy Infrastructure**
+   ```bash
+   cd infra/environments/dev
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+3. **Access Dashboard**
+   - Dashboard URL will be output after deployment
+   - Or find it in GCP Console → Monitoring → Dashboards
+
+## Configuration
+
+### Service Configuration
+```hcl
+module "cloud_run_service" {
+  source = "../../modules/cloud_run_service"
+  
+  service_name = "my-app"
+  region       = "us-central1"
+  image_url    = "gcr.io/your-project/your-app"
+  
+  # Adjust resources as needed
+  cpu_limit    = "1"
+  memory_limit = "512Mi"
+  
+  # Scaling settings
+  min_instances = 0
+  max_instances = 10
+}
+```
+
+### Monitoring Configuration
+```hcl
+module "monitoring" {
+  source = "../../modules/cloud_run_monitoring"
+  
+  service_name           = "my-app"
+  alert_email           = "alerts@yourcompany.com"
+  error_rate_threshold  = 5    # errors per minute
+  latency_threshold_ms  = 2000 # milliseconds
+}
+```
+
+## Log-Based Metrics
+
+The setup creates custom log-based metrics:
+
+1. **Error Rate Metric**: Counts HTTP 4xx/5xx responses and ERROR severity logs
+2. **Request Latency Metric**: Extracts latency from HTTP request logs
+
+## Best Practices Implemented
+
+✅ **Structured Logging**: Monitors both HTTP status codes and log severity levels  
+✅ **Rate Limiting**: Prevents alert spam with notification rate limits  
+✅ **Percentile Monitoring**: Uses 95th percentile for latency alerts  
+✅ **Resource Efficiency**: CPU idle mode to reduce costs  
+✅ **Security**: Dedicated service account with minimal permissions  
+✅ **Scalability**: Auto-scaling configuration with sensible defaults  
+
+## Customization
+
+### Adding More Metrics
+Add custom log-based metrics in `cloud_run_monitoring/main.tf`:
+
+```hcl
+resource "google_logging_metric" "custom_metric" {
+  name   = "${var.service_name}-custom-metric"
+  filter = "your-custom-filter-here"
+  
+  metric_descriptor {
+    metric_kind = "GAUGE"
+    value_type  = "INT64"
+  }
+}
+```
+
+### Additional Alert Conditions
+Extend alert policies with more conditions or create new policies for specific use cases.
+
+## Troubleshooting
+
+### Common Issues
+1. **Permission Errors**: Ensure your service account has Monitoring Admin and Logging Admin roles
+2. **No Data in Dashboard**: Verify your Cloud Run service is receiving traffic
+3. **Alerts Not Firing**: Check that log filters match your application's log format
+
+### Useful Commands
+```bash
+# Check service logs
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=my-app"
+
+# Test alert policies
+gcloud alpha monitoring policies list
+
+# View dashboard
+gcloud monitoring dashboards list
+```
+
+## Cost Optimization
+
+- Uses CPU idle mode to reduce costs when not serving requests
+- Configurable min/max instances for cost control
+- Log-based metrics only charge for log ingestion, not metric storage
+
+## Next Steps
+
+- Set up additional notification channels (Slack, PagerDuty)
+- Add custom business metrics
+- Implement SLO monitoring
+- Set up log-based SLI tracking

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,0 +1,58 @@
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+  
+  backend "gcs" {
+    bucket = "infra-new-state"
+    prefix = "examples/cloud-run-monitoring"
+  }
+}
+
+provider "google" {
+  project = "launchflow-services-dev"
+  region  = "us-central1"
+}
+
+locals {
+  service_name = "my-app"
+  alert_email  = "alerts@launchflow.com"
+}
+
+# Cloud Run service
+module "cloud_run_service" {
+  source = "../../modules/cloud_run_service"
+  
+  service_name = local.service_name
+  region       = "us-central1"
+  image_url    = "gcr.io/cloudrun/hello"  # Replace with your image
+  
+  # Resource limits
+  cpu_limit    = "1"
+  memory_limit = "512Mi"
+  
+  # Scaling
+  min_instances = 0
+  max_instances = 10
+  
+  # Environment variables
+  env_vars = {
+    ENV = "development"
+  }
+  
+  allow_public_access = true
+}
+
+# Monitoring setup
+module "monitoring" {
+  source = "../../modules/cloud_run_monitoring"
+  
+  service_name           = local.service_name
+  alert_email           = local.alert_email
+  error_rate_threshold  = 5    # 5 errors per minute
+  latency_threshold_ms  = 2000 # 2 seconds
+}

--- a/infra/modules/cloud_run_monitoring/main.tf
+++ b/infra/modules/cloud_run_monitoring/main.tf
@@ -1,0 +1,267 @@
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Log-based metric for error rate
+resource "google_logging_metric" "error_rate" {
+  name   = "${var.service_name}-error-rate"
+  filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND (severity=\"ERROR\" OR httpRequest.status>=400)"
+  
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+    display_name = "Cloud Run Error Rate"
+  }
+}
+
+# Log-based metric for request latency
+resource "google_logging_metric" "request_latency" {
+  name   = "${var.service_name}-request-latency"
+  filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND httpRequest.latency!=\"\""
+  
+  value_extractor = "REGEXP_EXTRACT(httpRequest.latency, \"([0-9.]+)s\")"
+  
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "DISTRIBUTION"
+    unit        = "s"
+    display_name = "Cloud Run Request Latency"
+  }
+  
+  bucket_options {
+    exponential_buckets {
+      num_finite_buckets = 64
+      growth_factor      = 2
+      scale              = 0.01
+    }
+  }
+}
+
+# Email notification channel
+resource "google_monitoring_notification_channel" "email" {
+  display_name = "${var.service_name} Email Alerts"
+  type         = "email"
+  labels = {
+    email_address = var.alert_email
+  }
+}
+
+# Alert policy for high error rate
+resource "google_monitoring_alert_policy" "high_error_rate" {
+  display_name = "${var.service_name} High Error Rate"
+  combiner     = "OR"
+  enabled      = true
+  
+  conditions {
+    display_name = "High error rate condition"
+    
+    condition_threshold {
+      filter          = "resource.type=\"cloud_run_revision\" AND metric.type=\"logging.googleapis.com/user/${google_logging_metric.error_rate.name}\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.error_rate_threshold
+      
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+  
+  notification_channels = [google_monitoring_notification_channel.email.name]
+  
+  documentation {
+    content = "Error rate for ${var.service_name} has exceeded ${var.error_rate_threshold} errors per minute."
+    mime_type = "text/markdown"
+  }
+}
+
+# Alert policy for high latency
+resource "google_monitoring_alert_policy" "high_latency" {
+  display_name = "${var.service_name} High Latency"
+  combiner     = "OR"
+  enabled      = true
+  
+  conditions {
+    display_name = "High latency condition"
+    
+    condition_threshold {
+      filter          = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND metric.type=\"run.googleapis.com/request_latencies\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = var.latency_threshold_ms
+      
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_PERCENTILE_95"
+      }
+    }
+  }
+  
+  notification_channels = [google_monitoring_notification_channel.email.name]
+  
+  documentation {
+    content = "95th percentile latency for ${var.service_name} has exceeded ${var.latency_threshold_ms}ms."
+    mime_type = "text/markdown"
+  }
+}
+
+# Log-based alert for critical errors
+resource "google_monitoring_alert_policy" "critical_errors" {
+  display_name = "${var.service_name} Critical Errors"
+  combiner     = "OR"
+  enabled      = true
+  
+  conditions {
+    display_name = "Critical error condition"
+    
+    condition_matched_log {
+      filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND (severity=\"CRITICAL\" OR severity=\"EMERGENCY\" OR jsonPayload.level=\"FATAL\")"
+    }
+  }
+  
+  notification_channels = [google_monitoring_notification_channel.email.name]
+  
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+  }
+  
+  documentation {
+    content = "Critical error detected in ${var.service_name} logs."
+    mime_type = "text/markdown"
+  }
+}
+
+# Monitoring dashboard
+resource "google_monitoring_dashboard" "cloud_run_dashboard" {
+  dashboard_json = jsonencode({
+    displayName = "${var.service_name} Monitoring Dashboard"
+    mosaicLayout = {
+      columns = 12
+      tiles = [
+        {
+          width = 6
+          height = 4
+          widget = {
+            title = "Request Count"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND metric.type=\"run.googleapis.com/request_count\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_RATE"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              timeshiftDuration = "0s"
+              yAxis = {
+                label = "Requests/sec"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          width = 6
+          height = 4
+          xPos = 6
+          widget = {
+            title = "Request Latency (95th percentile)"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND metric.type=\"run.googleapis.com/request_latencies\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_DELTA"
+                      crossSeriesReducer = "REDUCE_PERCENTILE_95"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              timeshiftDuration = "0s"
+              yAxis = {
+                label = "Latency (ms)"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          width = 6
+          height = 4
+          yPos = 4
+          widget = {
+            title = "Error Rate"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "resource.type=\"cloud_run_revision\" AND metric.type=\"logging.googleapis.com/user/${google_logging_metric.error_rate.name}\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_RATE"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              timeshiftDuration = "0s"
+              yAxis = {
+                label = "Errors/min"
+                scale = "LINEAR"
+              }
+            }
+          }
+        },
+        {
+          width = 6
+          height = 4
+          xPos = 6
+          yPos = 4
+          widget = {
+            title = "Instance Count"
+            xyChart = {
+              dataSets = [{
+                timeSeriesQuery = {
+                  timeSeriesFilter = {
+                    filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${var.service_name}\" AND metric.type=\"run.googleapis.com/container/instance_count\""
+                    aggregation = {
+                      alignmentPeriod    = "60s"
+                      perSeriesAligner   = "ALIGN_MEAN"
+                      crossSeriesReducer = "REDUCE_SUM"
+                    }
+                  }
+                }
+                plotType = "LINE"
+              }]
+              timeshiftDuration = "0s"
+              yAxis = {
+                label = "Instances"
+                scale = "LINEAR"
+              }
+            }
+          }
+        }
+      ]
+    }
+  })
+}

--- a/infra/modules/cloud_run_monitoring/outputs.tf
+++ b/infra/modules/cloud_run_monitoring/outputs.tf
@@ -1,0 +1,19 @@
+
+output "dashboard_url" {
+  description = "URL to the monitoring dashboard"
+  value       = "https://console.cloud.google.com/monitoring/dashboards/custom/${split("/", google_monitoring_dashboard.cloud_run_dashboard.id)[3]}"
+}
+
+output "notification_channel_id" {
+  description = "ID of the email notification channel"
+  value       = google_monitoring_notification_channel.email.name
+}
+
+output "alert_policy_ids" {
+  description = "IDs of the created alert policies"
+  value = {
+    high_error_rate = google_monitoring_alert_policy.high_error_rate.name
+    high_latency    = google_monitoring_alert_policy.high_latency.name
+    critical_errors = google_monitoring_alert_policy.critical_errors.name
+  }
+}

--- a/infra/modules/cloud_run_monitoring/variables.tf
+++ b/infra/modules/cloud_run_monitoring/variables.tf
@@ -1,0 +1,22 @@
+
+variable "service_name" {
+  description = "Name of the Cloud Run service to monitor"
+  type        = string
+}
+
+variable "alert_email" {
+  description = "Email address to send alerts to"
+  type        = string
+}
+
+variable "error_rate_threshold" {
+  description = "Error rate threshold (errors per minute) to trigger alert"
+  type        = number
+  default     = 5
+}
+
+variable "latency_threshold_ms" {
+  description = "Latency threshold in milliseconds to trigger alert"
+  type        = number
+  default     = 2000
+}

--- a/infra/modules/cloud_run_service/main.tf
+++ b/infra/modules/cloud_run_service/main.tf
@@ -1,0 +1,70 @@
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Service account for Cloud Run
+resource "google_service_account" "cloud_run" {
+  account_id   = "${var.service_name}-runner"
+  display_name = "Cloud Run Service Account for ${var.service_name}"
+}
+
+# Cloud Run service
+resource "google_cloud_run_v2_service" "service" {
+  name     = var.service_name
+  location = var.region
+
+  template {
+    service_account = google_service_account.cloud_run.email
+    
+    scaling {
+      min_instance_count = var.min_instances
+      max_instance_count = var.max_instances
+    }
+
+    containers {
+      image = var.image_url
+      
+      ports {
+        container_port = var.container_port
+      }
+
+      resources {
+        limits = {
+          cpu    = var.cpu_limit
+          memory = var.memory_limit
+        }
+        cpu_idle = true
+      }
+
+      # Environment variables
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+  }
+}
+
+# IAM binding to allow public access
+resource "google_cloud_run_v2_service_iam_binding" "public" {
+  count = var.allow_public_access ? 1 : 0
+  
+  location = google_cloud_run_v2_service.service.location
+  name     = google_cloud_run_v2_service.service.name
+  role     = "roles/run.invoker"
+  members  = ["allUsers"]
+}

--- a/infra/modules/cloud_run_service/outputs.tf
+++ b/infra/modules/cloud_run_service/outputs.tf
@@ -1,0 +1,15 @@
+
+output "service_url" {
+  description = "URL of the Cloud Run service"
+  value       = google_cloud_run_v2_service.service.uri
+}
+
+output "service_name" {
+  description = "Name of the Cloud Run service"
+  value       = google_cloud_run_v2_service.service.name
+}
+
+output "service_account_email" {
+  description = "Email of the service account"
+  value       = google_service_account.cloud_run.email
+}

--- a/infra/modules/cloud_run_service/variables.tf
+++ b/infra/modules/cloud_run_service/variables.tf
@@ -1,0 +1,57 @@
+
+variable "service_name" {
+  description = "Name of the Cloud Run service"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for the service"
+  type        = string
+}
+
+variable "image_url" {
+  description = "Container image URL"
+  type        = string
+}
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 8080
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the container"
+  type        = string
+  default     = "1"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the container"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "min_instances" {
+  description = "Minimum number of instances"
+  type        = number
+  default     = 0
+}
+
+variable "max_instances" {
+  description = "Maximum number of instances"
+  type        = number
+  default     = 10
+}
+
+variable "env_vars" {
+  description = "Environment variables for the container"
+  type        = map(string)
+  default     = {}
+}
+
+variable "allow_public_access" {
+  description = "Whether to allow public access to the service"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
# GCP Cloud Run Monitoring with Terraform

This PR adds comprehensive monitoring infrastructure for Google Cloud Run services using Terraform, including log-based alerts and latency monitoring dashboards.

## 🚀 Features Added

### Terraform Modules
- **`cloud_run_service`**: Deploys Cloud Run services with proper scaling and security
- **`cloud_run_monitoring`**: Sets up comprehensive monitoring with alerts and dashboards

### Alert Policies
- **High Error Rate**: Triggers when error rate exceeds 5 errors/minute (configurable)
- **High Latency**: Triggers when 95th percentile latency exceeds 2000ms (configurable)  
- **Critical Errors**: Log-based alert for CRITICAL/EMERGENCY/FATAL log entries

### Monitoring Dashboard
- Request count over time
- Request latency (95th percentile)
- Error rate tracking
- Instance count monitoring

### Log-Based Metrics
- **Error Rate Metric**: Counts HTTP 4xx/5xx responses and ERROR severity logs
- **Request Latency Metric**: Extracts and tracks request latency from logs

## 📁 Structure
```
infra/
├── modules/
│   ├── cloud_run_service/     # Cloud Run service deployment
│   └── cloud_run_monitoring/  # Monitoring setup
└── environments/
    └── dev/                   # Development environment config
```

## ⚙️ Configuration
- **GCP Project**: `launchflow-services-dev`
- **State Backend**: GCS bucket `infra-new-state` with prefix `examples/cloud-run-monitoring`
- **Alert Email**: `alerts@launchflow.com`

## 🛠️ Best Practices Implemented
✅ Structured logging monitoring (HTTP status codes + log severity)  
✅ Rate limiting to prevent alert spam  
✅ 95th percentile latency monitoring  
✅ CPU idle mode for cost optimization  
✅ Dedicated service accounts with minimal permissions  
✅ Auto-scaling with sensible defaults  
✅ Proper resource type filtering for GCP Monitoring API compliance

## 🚀 Quick Start
```bash
cd infra/environments/dev
terraform init
terraform apply
```

## 🔧 Fixes Applied
- Fixed log-based metrics to use `DELTA` metric kind (required for log-based metrics)
- Added proper `resource.type="cloud_run_revision"` filters for GCP Monitoring API compliance
- Used `REGEXP_EXTRACT` for proper latency value extraction from logs
- Configured proper notification channels with rate limiting

This provides a production-ready monitoring setup for Cloud Run services that can be easily customized and extended.

------------------------------------

Continue the chat at: http://localhost:5173/chat/0BtBnRVaQzBYtS54