### PR TITLE
Make GCP Cloud Run monitoring repo generic and shareable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,273 +1,114 @@
 
 # GCP Cloud Run Monitoring with Terraform
 
-This project sets up comprehensive monitoring for Google Cloud Run services including log-based alerts and latency monitoring dashboards.
+Complete monitoring setup for Google Cloud Run services with alerts and dashboards.
 
-## Features
+## What You Get
 
-### 🚨 Alert Policies
-- **High Error Rate**: Triggers when error rate exceeds threshold (default: 5 errors/minute)
-- **High Latency**: Triggers when 95th percentile latency exceeds threshold (default: 2000ms)
-- **Critical Errors**: Log-based alert for CRITICAL/EMERGENCY/FATAL log entries
-
-### 📊 Monitoring Dashboard
-- Request count over time
-- Request latency (95th percentile)
-- Error rate tracking
-- Instance count monitoring
-
-### 📧 Notifications
-- Email notifications for all alerts
-- Rate limiting to prevent spam (max 1 notification per 5 minutes for log-based alerts)
+- **Error Rate Alerts**: Triggers when errors exceed 5/minute (configurable)
+- **Latency Alerts**: Triggers when 95th percentile latency exceeds 2000ms (configurable)  
+- **Critical Error Alerts**: Log-based alerts for CRITICAL/EMERGENCY/FATAL entries
+- **Monitoring Dashboard**: Request count, latency, error rate, and instance metrics
+- **Email Notifications**: With rate limiting to prevent spam
 
 ## Quick Start
 
-### 1. Prerequisites
-- [Terraform](https://www.terraform.io/downloads.html) installed
-- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) installed and authenticated
-- GCP project with the following APIs enabled:
-  - Cloud Run API
-  - Cloud Monitoring API
-  - Cloud Logging API
+1. **Prerequisites**
+   - Terraform installed
+   - `gcloud` CLI authenticated
+   - GCP project with Cloud Run, Monitoring, and Logging APIs enabled
 
-### 2. Configuration
-
-1. **Clone this repository**
+2. **Configure**
    ```bash
-   git clone <repository-url>
-   cd gcp-cloud-run-monitoring
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your values
    ```
 
-2. **Configure your environment**
-   
-   Edit `infra/environments/dev/main.tf` and update the `locals` block:
-   ```hcl
-   locals {
-     gcp_project_id = "your-actual-project-id"
-     region         = "us-central1"  # or your preferred region
-     service_name   = "your-app-name"
-     alert_email    = "your-email@example.com"
-   }
+3. **Deploy**
+   ```bash
+   cd infra/environments/dev
+   terraform init
+   terraform plan
+   terraform apply
    ```
 
-3. **Configure state backend (optional)**
-   
-   Choose one of the following options in `infra/environments/dev/main.tf`:
+4. **Access Dashboard**
+   - Dashboard URL will be in the terraform output
+   - Or find it in GCP Console → Monitoring → Dashboards
 
-   **Option A: Local state (default)**
-   ```hcl
-   # No backend configuration needed - uses local state
-   ```
+## Configuration
 
-   **Option B: Google Cloud Storage**
-   ```hcl
-   backend "gcs" {
-     bucket = "your-terraform-state-bucket"
-     prefix = "cloud-run-monitoring/dev"
-   }
-   ```
+Edit `terraform.tfvars`:
 
-   **Option C: AWS S3**
-   ```hcl
-   backend "s3" {
-     bucket = "your-terraform-state-bucket"
-     key    = "cloud-run-monitoring/dev/terraform.tfstate"
-     region = "us-east-1"
-   }
-   ```
+```hcl
+gcp_project_id = "your-project-id"
+service_name   = "my-app"
+alert_email    = "alerts@example.com"
+image_url      = "gcr.io/your-project/your-app"
 
-### 3. Deploy Infrastructure
-
-```bash
-cd infra/environments/dev
-terraform init
-terraform plan
-terraform apply
+# Optional customizations
+error_rate_threshold = 5     # errors per minute
+latency_threshold_ms = 2000  # milliseconds
+min_instances        = 0
+max_instances        = 10
 ```
 
-### 4. Access Dashboard
-- Dashboard URL will be output after deployment
-- Or find it in GCP Console → Monitoring → Dashboards
+## State Backend Options
 
-## Configuration Options
+Choose one in `infra/environments/dev/main.tf`:
 
-### Service Configuration
 ```hcl
-module "cloud_run_service" {
-  source = "../../modules/cloud_run_service"
-  
-  service_name = "my-app"
-  region       = "us-central1"
-  image_url    = "gcr.io/your-project/your-app"
-  
-  # Adjust resources as needed
-  cpu_limit    = "1"
-  memory_limit = "512Mi"
-  
-  # Scaling settings
-  min_instances = 0
-  max_instances = 10
-  
-  # Environment variables
-  env_vars = {
-    ENV = "production"
-    API_KEY = "your-api-key"
-  }
-  
-  # Access control
-  allow_public_access = true  # Set to false for private services
+# Local state (default)
+# No backend block needed
+
+# GCS backend
+backend "gcs" {
+  bucket = "your-terraform-state-bucket"
+  prefix = "cloud-run-monitoring/dev"
+}
+
+# S3 backend  
+backend "s3" {
+  bucket = "your-terraform-state-bucket"
+  key    = "cloud-run-monitoring/dev/terraform.tfstate"
+  region = "us-east-1"
 }
 ```
 
-### Monitoring Configuration
-```hcl
-module "monitoring" {
-  source = "../../modules/cloud_run_monitoring"
-  
-  service_name           = "my-app"
-  alert_email           = "alerts@yourcompany.com"
-  error_rate_threshold  = 5    # errors per minute
-  latency_threshold_ms  = 2000 # milliseconds
-}
-```
+## What's Monitored
 
-## Multiple Environments
-
-To set up multiple environments (dev, staging, prod), create additional environment directories:
-
-```
-infra/
-├── environments/
-│   ├── dev/
-│   │   └── main.tf
-│   ├── staging/
-│   │   └── main.tf
-│   └── prod/
-│       └── main.tf
-└── modules/
-    ├── cloud_run_service/
-    └── cloud_run_monitoring/
-```
-
-Each environment can have different configurations for scaling, alerting thresholds, and resource limits.
-
-## Log-Based Metrics
-
-The setup creates custom log-based metrics:
-
-1. **Error Rate Metric**: Counts HTTP 4xx/5xx responses and ERROR severity logs
-2. **Request Latency Metric**: Extracts latency from HTTP request logs
-
-## Best Practices Implemented
-
-✅ **Structured Logging**: Monitors both HTTP status codes and log severity levels  
-✅ **Rate Limiting**: Prevents alert spam with notification rate limits  
-✅ **Percentile Monitoring**: Uses 95th percentile for latency alerts  
-✅ **Resource Efficiency**: CPU idle mode to reduce costs  
-✅ **Security**: Dedicated service account with minimal permissions  
-✅ **Scalability**: Auto-scaling configuration with sensible defaults  
-
-## Customization
-
-### Adding More Metrics
-Add custom log-based metrics in `cloud_run_monitoring/main.tf`:
-
-```hcl
-resource "google_logging_metric" "custom_metric" {
-  name   = "${var.service_name}-custom-metric"
-  filter = "your-custom-filter-here"
-  
-  metric_descriptor {
-    metric_kind = "GAUGE"
-    value_type  = "INT64"
-  }
-}
-```
-
-### Additional Alert Conditions
-Extend alert policies with more conditions or create new policies for specific use cases.
-
-### Custom Notification Channels
-Add Slack, PagerDuty, or other notification channels:
-
-```hcl
-resource "google_monitoring_notification_channel" "slack" {
-  display_name = "Slack Alerts"
-  type         = "slack"
-  labels = {
-    channel_name = "#alerts"
-    url          = "https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK"
-  }
-}
-```
+- **HTTP Errors**: 4xx/5xx status codes
+- **Log Errors**: ERROR severity logs
+- **Request Latency**: 95th percentile response times
+- **Critical Logs**: CRITICAL/EMERGENCY/FATAL severity
+- **Instance Count**: Auto-scaling metrics
 
 ## Troubleshooting
 
-### Common Issues
+**Permission errors?** Ensure your account has:
+- Monitoring Admin
+- Logging Admin  
+- Cloud Run Admin
 
-1. **Permission Errors**: Ensure your service account has the following roles:
-   - Monitoring Admin
-   - Logging Admin
-   - Cloud Run Admin
+**No dashboard data?** 
+- Check your service is receiving traffic
+- Verify service name matches in both modules
 
-2. **No Data in Dashboard**: 
-   - Verify your Cloud Run service is receiving traffic
-   - Check that the service name matches in both modules
+**Alerts not firing?**
+- Test with some traffic to trigger thresholds
+- Check alert thresholds match your expected traffic patterns
 
-3. **Alerts Not Firing**: 
-   - Check that log filters match your application's log format
-   - Verify alert thresholds are appropriate for your traffic
+## File Structure
 
-4. **State Backend Issues**:
-   - For GCS: Ensure the bucket exists and you have access
-   - For S3: Ensure AWS credentials are configured
-
-### Useful Commands
-
-```bash
-# Check service logs
-gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=my-app" --project=your-project-id
-
-# Test alert policies
-gcloud alpha monitoring policies list --project=your-project-id
-
-# View dashboard
-gcloud monitoring dashboards list --project=your-project-id
-
-# Check Terraform state
-terraform state list
-terraform show
+```
+infra/
+├── environments/dev/     # Environment-specific config
+│   ├── main.tf          # Main configuration
+│   ├── variables.tf     # Input variables
+│   └── outputs.tf       # Output values
+└── modules/
+    ├── cloud_run_service/     # Cloud Run service module
+    └── cloud_run_monitoring/  # Monitoring setup module
 ```
 
-## Cost Optimization
-
-- Uses CPU idle mode to reduce costs when not serving requests
-- Configurable min/max instances for cost control
-- Log-based metrics only charge for log ingestion, not metric storage
-- Consider using preemptible instances for non-critical workloads
-
-## Security Considerations
-
-- Service account follows principle of least privilege
-- Consider using Workload Identity for enhanced security
-- Review IAM bindings regularly
-- Use Secret Manager for sensitive environment variables
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test with `terraform plan`
-5. Submit a pull request
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## Support
-
-For issues and questions:
-- Check the troubleshooting section above
-- Review Terraform and GCP documentation
-- Open an issue in this repository
+Copy the `dev` environment to create `staging` or `prod` with different configurations.


### PR DESCRIPTION
Refactored the repository to remove hardcoded account-specific details and make it easily configurable for different users and projects.

## Changes Made

### 🔧 Configuration Improvements
- **Removed hardcoded values**: Eliminated specific GCP project ID, bucket names, and email addresses
- **Added variable-based configuration**: Created `variables.tf` with all configurable options
- **Added terraform.tfvars.example**: Template file for easy setup
- **Multiple state backend support**: Added examples for local, GCS, and S3 backends

### 📚 Documentation Overhaul  
- **Simplified README**: Condensed from verbose documentation to concise, Reddit-friendly format
- **Quick start guide**: Clear 4-step setup process
- **Configuration examples**: Easy-to-follow terraform.tfvars examples
- **Troubleshooting section**: Essential debugging info without overwhelming detail

### 🏗️ Infrastructure Updates
- **Flexible provider configuration**: Uses variables instead of hardcoded locals
- **Added outputs.tf**: Provides important resource information after deployment
- **Enhanced .gitignore**: Prevents committing sensitive terraform files
- **Consistent variable usage**: All modules now use configurable variables

### 🎯 User Experience
- **Copy-paste ready**: Users can clone, configure terraform.tfvars, and deploy
- **Multiple environment support**: Easy to create dev/staging/prod environments  
- **State backend flexibility**: Choose between local, GCS, or S3 state storage
- **Maintained functionality**: All monitoring features preserved while improving usability

The repository is now completely generic and ready for sharing while maintaining all the original monitoring capabilities including error rate alerts, latency monitoring, and comprehensive dashboards.

------------------------------------

Continue the chat at: http://localhost:5173/chat/III9Tuf7IoVyBdoF