### PR TITLE
Refactor GCP Cloud Run monitoring repo for public sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@
 
 Complete monitoring setup for Google Cloud Run services with alerts and dashboards.
 
+## File Structure
+
+```
+infra/
+├── environments/dev/     # Environment-specific config
+│   ├── main.tf          # Main configuration
+│   ├── variables.tf     # Input variables
+│   └── outputs.tf       # Output values
+└── modules/
+    ├── cloud_run_service/     # Cloud Run service module
+    └── cloud_run_monitoring/  # Monitoring setup module
+```
+
+Copy the `dev` environment to create `staging` or `prod` with different configurations.
+
 ## What You Get
 
 - **Error Rate Alerts**: Triggers when errors exceed 5/minute (configurable)
@@ -97,18 +112,3 @@ backend "s3" {
 **Alerts not firing?**
 - Test with some traffic to trigger thresholds
 - Check alert thresholds match your expected traffic patterns
-
-## File Structure
-
-```
-infra/
-├── environments/dev/     # Environment-specific config
-│   ├── main.tf          # Main configuration
-│   ├── variables.tf     # Input variables
-│   └── outputs.tf       # Output values
-└── modules/
-    ├── cloud_run_service/     # Cloud Run service module
-    └── cloud_run_monitoring/  # Monitoring setup module
-```
-
-Copy the `dev` environment to create `staging` or `prod` with different configurations.


### PR DESCRIPTION
Made the repository generic and shareable by removing hardcoded account-specific details and adding flexible configuration options.

**Key Changes:**
- Removed hardcoded GCP project ID, bucket name, and email addresses
- Added variable-based configuration with `terraform.tfvars.example` template
- Added support for multiple state backends (local, GCS, S3)
- Simplified and streamlined README for better readability
- Added proper `.gitignore` to prevent committing sensitive files
- Moved file structure to top of README for better organization

**Configuration is now flexible:**
- Users can easily plug in their own GCP project
- Configurable alert thresholds and resource limits
- Support for different state backends
- Easy to extend for multiple environments

The repo is now ready for public sharing while maintaining all monitoring functionality.

------------------------------------

Continue the chat at: http://localhost:5173/chat/III9Tuf7IoVyBdoF